### PR TITLE
Resource.get now returns null

### DIFF
--- a/lib/trapper_keeper/engines/mongodb.js
+++ b/lib/trapper_keeper/engines/mongodb.js
@@ -49,7 +49,7 @@ util.inherits(Mongodb, Engine);
 
 // Normalize a mongo _id property into an id property
 function normalize(obj) {
-  if(!obj) return null;
+  if(!obj) return;
 
   if(obj._id) {
     obj.id = obj._id.toString();
@@ -68,7 +68,7 @@ Mongodb.prototype.get = function get(id, namespace, callback) {
     collection.findOne(id, function(err, doc) {
       if(err) return callback(err);
 
-      callback(null, normalize(doc));
+      callback(null, normalize(doc) || null);
     });
   });
 };

--- a/test/engines/mongodb.js
+++ b/test/engines/mongodb.js
@@ -88,7 +88,7 @@ describe('mongodb', function() {
     it('should destroy a record', function(done) {
       resource.destroy(document.id, function(err, result) {
         resource.get(document.id, function(err, res) {
-          res.should.eql({});
+          should.not.exist(res);
           done();
         });
       });


### PR DESCRIPTION
Resource.get now returns null when no model with that `id` is found. This prevents from having to check if the object is empty later down in the callback chain. 
This allows for a simple if(!object) in the callback function, rather than a !Object.keys(object).length. However this might not be the intended functionality.
